### PR TITLE
Added utility function to read float directly from holding registers

### DIFF
--- a/src/client.toit
+++ b/src/client.toit
@@ -105,6 +105,14 @@ class Client:
           logger_.warn "unpaired response"
     finally:
       close
+  
+  /**
+  Utility function to fetch a REAL/FLOAT from holding registers
+  */
+  read_float start_address/int -> float:
+    registers := this.read_holding_registers start_address 2
+    return float.from_bits32(registers[0] << 16 | registers[1])
+  
 
 monitor Sessions_:
   sessions_ ::= {:}


### PR DESCRIPTION
Added utility function to read and parse floats (or REALs in Modbus terminology) directly like:
`my_float := client.read_float <address>`