### PR TITLE
Add RTU example.

### DIFF
--- a/examples/modbus_rtu.toit
+++ b/examples/modbus_rtu.toit
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the EXAMPLES_LICENSE file.
+
+import gpio
+import log
+import modbus
+import rs485
+
+RX ::= 17
+TX ::= 16
+RTS ::= 18
+BAUD_RATE ::= 9600
+
+main:
+  log.set_default (log.default.with_level log.INFO_LEVEL)
+
+  pin_rx := gpio.Pin  RX
+  pin_tx := gpio.Pin  TX
+  pin_rts := gpio.Pin RTS
+
+  rs485_bus := rs485.Rs485
+      --rx=pin_rx
+      --tx=pin_tx
+      --rts=pin_rts
+      --baud_rate=BAUD_RATE
+
+  bus := modbus.Modbus.rtu rs485_bus
+
+  station := bus.station 1
+
+  holding_registers := station.holding_registers
+
+  holding_registers.write_many --address=101 [42]
+  holding_registers.write_many --address=102 [2]
+  holding_registers.write_many --address=103 [44]
+
+  print
+    holding_registers.read_many --address=101 --register_count=3
+
+  // See the TCP example for other modbus operations.
+
+  bus.close
+  rs485_bus.close

--- a/examples/modbus_rtu.toit
+++ b/examples/modbus_rtu.toit
@@ -36,7 +36,7 @@ main:
   holding_registers.write_many --address=103 [44]
 
   print
-    holding_registers.read_many --address=101 --register_count=3
+      holding_registers.read_many --address=101 --register_count=3
 
   // See the TCP example for other modbus operations.
 

--- a/examples/modbus_tcp.toit
+++ b/examples/modbus_tcp.toit
@@ -23,7 +23,7 @@ main:
   holding_registers.write_many --address=103 [44]
 
   print
-    holding_registers.read_many --address=101 --register_count=3
+      holding_registers.read_many --address=101 --register_count=3
 
 
   // Some convenience functions:
@@ -41,7 +41,7 @@ main:
   uint32 := 42
   holding_registers.write_uint32 --address=300 uint32
   print
-    holding_registers.read_uint32 --address=300
+      holding_registers.read_uint32 --address=300
 
 
   input_registers := station.input_registers

--- a/examples/modbus_tcp.toit
+++ b/examples/modbus_tcp.toit
@@ -2,10 +2,13 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the EXAMPLES_LICENSE file.
 
+import log
 import net
 import modbus
 
 main:
+  log.set_default (log.default.with_level log.INFO_LEVEL)
+
   net := net.open
   socket := net.tcp_connect "localhost" 5502
 

--- a/examples/package.lock
+++ b/examples/package.lock
@@ -1,5 +1,7 @@
+sdk: ^2.0.0-alpha.21
 prefixes:
   modbus: ..
+  rs485: toit-rs485
 packages:
   ..:
     path: ..
@@ -7,5 +9,5 @@ packages:
       rs485: toit-rs485
   toit-rs485:
     url: github.com/toitware/toit-rs485
-    version: 1.0.1
-    hash: 854d96a9d27b6ce7325a9698001087b292f4b4b5
+    version: 1.1.0
+    hash: 607b0acb6a1e222eb36727c2818b82365b332fa9

--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -1,3 +1,6 @@
 dependencies:
   modbus:
     path: ..
+  rs485:
+    url: github.com/toitware/toit-rs485
+    version: ^1.1.0

--- a/src/bus.toit
+++ b/src/bus.toit
@@ -72,6 +72,19 @@ class Modbus:
   Convenience constructor for creating a new RTU Modbus Client.
   */
   constructor.rtu rs485_bus/rs485.Rs485
+      --framer/Framer=(RtuFramer --baud_rate=rs485_bus.baud_rate)
+      --auto_run=true:
+    return Modbus
+      Rs485Transport rs485_bus --framer=framer
+      --auto_run=auto_run
+
+  /**
+  Variant of $Modbus.constructor.
+  Convenience constructor for creating a new RTU Modbus Client.
+
+  Deprecated. Use the constructor without `--baud_rate` instead.
+  */
+  constructor.rtu rs485_bus/rs485.Rs485
       --baud_rate/int
       --framer/Framer=(RtuFramer --baud_rate=baud_rate)
       --auto_run=true:


### PR DESCRIPTION
Also deprecate the constructor that requires an explicit baudrate
argument.