### PR TITLE
Allow 0 as station id for non-broadcast.

### DIFF
--- a/src/bus.toit
+++ b/src/bus.toit
@@ -111,16 +111,21 @@ class Modbus:
     "server address". For Modbus TCP, it should almost always be equal to $Station.IGNORED_UNIT_ID (the default).
     For Modbus RTU or Modbus ASCII, it needs to be set to the id of the server.
 
-  For Modbus RTU or Modbus ASCII, the id 0 is reserved for broadcast messages. This bus will never assume that
-    a message to a station with id 0 expects a response. This is true, even for Modbus TCP instantiations.
+  If the id is 0 (the $Station.BROADCAST_UNIT_ID), then the station is assumed to be used for broadcast
+    messages. In that case messages don't expect a response and "read" functions will fail. If
+    a station with id 0 should not be treated as a broadcast station, use the $is_broadcast flag to
+    override the behavior.
   */
-  station unit_id/int=Station.IGNORED_UNIT_ID --logger/log.Logger=logger_ -> Station:
-    return Station.from_bus_ this unit_id --logger=logger
+  station -> Station
+      unit_id/int=Station.IGNORED_UNIT_ID
+      --logger/log.Logger=logger_
+      --is_broadcast/bool=(unit_id == Station.BROADCAST_UNIT_ID):
+    return Station.from_bus_ this unit_id --logger=logger --is_broadcast=is_broadcast
 
   broadcast_station --logger/log.Logger -> Station:
-    return Station.from_bus_ this Station.BROADCAST_UNIT_ID --logger=logger
+    return Station.from_bus_ this Station.BROADCAST_UNIT_ID --logger=logger --is_broadcast
 
-  send_ --unit_id/int request/Request [deserialize_response] -> protocol.Response?:
+  send_ --unit_id/int request/Request [deserialize_response] --is_broadcast/bool -> protocol.Response?:
     if is_closed: throw "BUS_CLOSED"
     id := transactions_.enter
     try:

--- a/src/bus.toit
+++ b/src/bus.toit
@@ -112,14 +112,14 @@ class Modbus:
     For Modbus RTU or Modbus ASCII, it needs to be set to the id of the server.
 
   If the id is 0 (the $Station.BROADCAST_UNIT_ID), then the station is assumed to be used for broadcast
-    messages. In that case messages don't expect a response and "read" functions will fail. If
-    a station with id 0 should not be treated as a broadcast station, use the $is_broadcast flag to
-    override the behavior.
+    messages. In that case messages don't expect a response and "read" functions will fail. Use the
+    $force_non_broadcast flag to use a station with id 0 as a regular station.
   */
   station -> Station
       unit_id/int=Station.IGNORED_UNIT_ID
       --logger/log.Logger=logger_
-      --is_broadcast/bool=(unit_id == Station.BROADCAST_UNIT_ID):
+      --force_non_broadcast/bool=false:
+    is_broadcast := unit_id == Station.BROADCAST_UNIT_ID and not force_non_broadcast
     return Station.from_bus_ this unit_id --logger=logger --is_broadcast=is_broadcast
 
   broadcast_station --logger/log.Logger -> Station:

--- a/src/bus.toit
+++ b/src/bus.toit
@@ -132,7 +132,7 @@ class Modbus:
       frame := Frame --transaction_id=id --unit_id=unit_id --function_code=request.function_code --data=request.to_byte_array
       transactions_.write id frame
       response_frame/Frame? := null
-      if unit_id == Station.BROADCAST_UNIT_ID: return null
+      if is_broadcast: return null
       with_timeout --ms=READ_TIMEOUT_MS_:
         response_frame = transactions_.read id
       return deserialize_response.call response_frame

--- a/tests/package.lock
+++ b/tests/package.lock
@@ -1,3 +1,4 @@
+sdk: ^1.6.10
 prefixes:
   host: pkg-host
   modbus: ..


### PR DESCRIPTION
However, users have to proved a `--is_broadcast=false` flag in that case.