### PR TITLE
Update GPIO usage for SDK 2.0 alpha 196

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,9 @@ jobs:
       matrix:
         # TODO: test on windows.
         os: [ ubuntu-latest, macos-latest ]
-        # The versions should contain (at least) the lowest requirement
-        #    and a version that is more up to date.
-        toit-version: [ v2.0.0-alpha.170, latest ]
+        toit-version: [ oldest, latest ]
         include:
-          - toit-version: v2.0.0-alpha.170
+          - toit-version: oldest
             version-name: old
           - toit-version: latest
             version-name: new
@@ -27,9 +25,22 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Resolve Toit version
+        id: toit-version
+        shell: bash
+        run: |
+          if [[ "${{ matrix.toit-version }}" == "oldest" ]]; then
+            sdk=$(grep -E '^[[:space:]]+sdk:' package.yaml | head -1 \
+              | sed -E 's/^[[:space:]]+sdk:[[:space:]]*//; s/^\^//' \
+              | tr -d "\"' ")
+            echo "version=v$sdk" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=latest" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: toitlang/action-setup@v1
         with:
-          toit-version: ${{ matrix.toit-version }}
+          toit-version: ${{ steps.toit-version.outputs.version }}
 
       - name: Setup Python
         uses: actions/setup-python@v7

--- a/examples/modbus_rtu.toit
+++ b/examples/modbus_rtu.toit
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the EXAMPLES_LICENSE file.
 
-import gpio
 import log
 import modbus
 import rs485
@@ -10,20 +9,16 @@ import rs485
 RX ::= 17
 TX ::= 16
 RTS ::= 18
-BAUD_RATE ::= 9600
+BAUD-RATE ::= 9600
 
 main:
   log.set_default (log.default.with_level log.INFO_LEVEL)
 
-  pin_rx := gpio.Pin  RX
-  pin_tx := gpio.Pin  TX
-  pin_rts := gpio.Pin RTS
-
   rs485_bus := rs485.Rs485
-      --rx=pin_rx
-      --tx=pin_tx
-      --rts=pin_rts
-      --baud_rate=BAUD_RATE
+      --rx=RX
+      --tx=TX
+      --rts=RTS
+      --baud-rate=BAUD-RATE
 
   bus := modbus.Modbus.rtu rs485_bus
 

--- a/examples/package.lock
+++ b/examples/package.lock
@@ -1,14 +1,13 @@
-sdk: ^2.0.0-alpha.144
+sdk: ^2.0.0-alpha.196
 prefixes:
-  modbus: ..
-  rs485: toit-rs485
+  modbus: pkg-modbus
+  rs485: github.com/toitware/toit-rs485-1
 packages:
-  ..:
+  github.com/toitware/toit-rs485-1:
+    hash: 90fdd6098568f38084a55f31f822b9afa5764f9d
+    url: github.com/toitware/toit-rs485
+    version: 1.4.0
+  pkg-modbus:
     path: ..
     prefixes:
-      rs485: toit-rs485
-  toit-rs485:
-    url: github.com/toitware/toit-rs485
-    name: rs485
-    version: 1.3.1
-    hash: d27ecefa1ee5acd6fdc23472712d046c5eca1693
+      rs485: github.com/toitware/toit-rs485-1

--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -3,4 +3,4 @@ dependencies:
     path: ..
   rs485:
     url: github.com/toitware/toit-rs485
-    version: ^1.3.1
+    version: ^1.4.0

--- a/package.lock
+++ b/package.lock
@@ -1,9 +1,8 @@
-sdk: ^2.0.0-alpha.170
+sdk: ^2.0.0-alpha.196
 prefixes:
-  rs485: toit-rs485
+  rs485: github.com/toitware/toit-rs485-1
 packages:
-  toit-rs485:
+  github.com/toitware/toit-rs485-1:
+    hash: 90fdd6098568f38084a55f31f822b9afa5764f9d
     url: github.com/toitware/toit-rs485
-    name: rs485
-    version: 1.3.1
-    hash: d27ecefa1ee5acd6fdc23472712d046c5eca1693
+    version: 1.4.0

--- a/package.yaml
+++ b/package.yaml
@@ -1,7 +1,7 @@
 name: modbus
 description: A Modbus Toit client.
 environment:
-  sdk: ^2.0.0-alpha.170
+  sdk: ^2.0.0-alpha.196
 dependencies:
   rs485:
     url: github.com/toitware/toit-rs485

--- a/package.yaml
+++ b/package.yaml
@@ -5,4 +5,4 @@ environment:
 dependencies:
   rs485:
     url: github.com/toitware/toit-rs485
-    version: ^1.3.1
+    version: ^1.4.0

--- a/tests/package.lock
+++ b/tests/package.lock
@@ -1,19 +1,17 @@
-sdk: ^2.0.0-alpha.170
+sdk: ^2.0.0-alpha.196
 prefixes:
-  host: pkg-host
-  modbus: ..
+  host: github.com/toitlang/pkg-host-1
+  modbus: pkg-modbus
 packages:
-  ..:
+  github.com/toitlang/pkg-host-1:
+    hash: d7a30b86c73cf8d9cd5dd0211031c76b68706738
+    url: github.com/toitlang/pkg-host
+    version: 1.19.0
+  github.com/toitware/toit-rs485-1:
+    hash: 90fdd6098568f38084a55f31f822b9afa5764f9d
+    url: github.com/toitware/toit-rs485
+    version: 1.4.0
+  pkg-modbus:
     path: ..
     prefixes:
-      rs485: toit-rs485
-  pkg-host:
-    url: github.com/toitlang/pkg-host
-    name: host
-    version: 1.16.2
-    hash: ae83f761db80166a20bb38498edd009916b72563
-  toit-rs485:
-    url: github.com/toitware/toit-rs485
-    name: rs485
-    version: 1.3.1
-    hash: d27ecefa1ee5acd6fdc23472712d046c5eca1693
+      rs485: github.com/toitware/toit-rs485-1

--- a/tests/package.yaml
+++ b/tests/package.yaml
@@ -1,6 +1,6 @@
 dependencies:
   host:
     url: github.com/toitlang/pkg-host
-    version: ^1.16.2
+    version: ^1.19.0
   modbus:
     path: ..


### PR DESCRIPTION
Updates the package for the SDK 2.0.0-alpha.196 peripheral API by passing integer GPIO numbers to peripheral constructors and raising the SDK constraint. It also brings the package publishing workflow up to date where needed.